### PR TITLE
Remove 'contains' command for octave compatability

### DIFF
--- a/CplxGPR/CplxGPapprox.m
+++ b/CplxGPR/CplxGPapprox.m
@@ -12,20 +12,21 @@ model.lognoisevariance=opts.lnv;
 if ~isempty(opts.lb) && ~isempty(opts.ub)
     CplxCov=CplxCov.set_bounds(opts.lb, opts.ub)
 else
-    if contains(cov_model, 'Szego')
+    if strcmp (cov_model, 'Szego')
         [lb,ub] = CplxCov.get_bounds();
         lb(2) = lb(2)*(max(xi)-min(xi));
         ub(2) =    ub(2)*(max(xi)-min(xi));
         CplxCov=CplxCov.set_bounds(lb, ub);
     end
 end
-if isempty(opts.p0) && contains(cov_model, 'Szego')
+
+if isempty (opts.p0) && strcmp (cov_model, 'Szego')
     [param0, lnv]  = CplxCov.get_params_init();
     param0(2) = param0(2)*(max(xi)-min(xi)); % rescale w.r.t. size of interval
     CplxCov = CplxCov.set_params_init(param0, lnv);
 end
 
-if contains(cov_model, 'Szego') && isfield(opts, 'SzegoPrior')
+if strcmp (cov_model, 'Szego') && isfield (opts, 'SzegoPrior')
     mode = opts.SzegoPrior(1) * (max(xi) - min(xi));
     sigma = opts.SzegoPrior(2);
     model.prior = szego_param_prior (mode, sigma);

--- a/scripts/run_ConvStudies.m
+++ b/scripts/run_ConvStudies.m
@@ -106,9 +106,8 @@ end
 
 %% Illustrate function
 
-if ~ contains (fun_name, 'Circuit')
+if isempty (strfind (fun_name, 'Circuit')) %#ok<STREMP>
     % (for the 'circuit' case, see draw_illustration_Circuit.m)
-
     [~, ~, x_cv, y_cv] = f(1);
     x_cv = scale_x * x_cv;
     y_cv = scale_y * y_cv;

--- a/utils/ConvStudy.m
+++ b/utils/ConvStudy.m
@@ -12,18 +12,16 @@ function [errorsRMSE, errorsMax, Nsz, errorsRMSE_Median, errorsMax_Median] = Con
         Nruns=1;
     end
 
-      
     Nsz=zeros(size(Nz));
     errorsRMSE = zeros(length(Nz),Nruns);
     errorsMax = zeros(length(Nz), Nruns);
-    if contains(name, 'Adap')
+    if strcmp (name, 'Adap')
         errorsRMSEfull = NaN(length(Nz), Nruns, 15);
         errorsMaxfull = NaN(length(Nz), Nruns,15);
     end
-    
-   
+
     for j = 1:Nruns
-        
+
     %% Test points
     if ~discrete
         x_cv = linspace(xmin,xmax,n_cv)';
@@ -35,9 +33,7 @@ function [errorsRMSE, errorsMax, Nsz, errorsRMSE_Median, errorsMax_Median] = Con
     else
         [~,~, x_cv, y_cv] = f(1);
     end
-    
 
-    
     %% Convergence Study
     for i=1:length(Nz)
         tic;
@@ -58,12 +54,12 @@ function [errorsRMSE, errorsMax, Nsz, errorsRMSE_Median, errorsMax_Median] = Con
         end
         Nsz(i)=length(xi);
        % try
-            if contains(name, 'Adap')
+            if strcmp (name, 'Adap')
                 [Approx, ~, ~, ~, ~, ~, ~, data,~] = method(xi, yi, x_cv);
                 for k = 1:length(data)
                     [errorsRMSEfull(i,j,k), errorsMaxfull(i,j,k)] = compute_approx_error(data{k}.Mean, y_cv);
                 end
-            elseif contains(name, 'Cheb')
+            elseif strcmp(name, 'Chebyshev')
                 xc = cos((2*(1:Nz(i))-1)/2/Nz(i)*pi)'; % Chebyshev nodes
                 xc = (xmax-xmin)/2*xc+(xmax+xmin)/2; % Scale and shift
                 if Nruns ==1
@@ -71,21 +67,20 @@ function [errorsRMSE, errorsMax, Nsz, errorsRMSE_Median, errorsMax_Median] = Con
                 else
                     yc = f(xc, j);
                 end
-                Approx=method(xc, yc, x_cv); 
+                Approx=method(xc, yc, x_cv);
             else
                 Approx = method(xi, yi, x_cv);
             end
      %   catch
      %       Approx = method(xi, yi, x_cv,j); %% Very, very ugly workaround for fully adaptive approximation
       %  end
-                
+
         [errorsRMSE(i,j), errorsMax(i,j)] = compute_approx_error(Approx, y_cv, name);
 
         fprintf('Approximation: %s. Run %i of %i. Repetition %i of %i. Evaluation took %f s.\n', name, i, length(Nz),j, Nruns, toc);
     end
     end
-    
-        
+
     if nargout>3
          errorsRMSE_Median = median(errorsRMSE,2);
          errorsMax_Median = median(errorsMax,2);
@@ -93,7 +88,7 @@ function [errorsRMSE, errorsMax, Nsz, errorsRMSE_Median, errorsMax_Median] = Con
 
     %% Store results
     save(['results/' name '.mat'], 'errorsRMSE', 'errorsMax', 'Nsz');
-    if contains(name, 'Adap')
+    if strcmp(name, 'Adap')
         save(['results/' name 'Full.mat'], 'errorsRMSE', 'errorsMax', 'Nsz', 'errorsRMSEfull', 'errorsMaxfull');
     end
 
@@ -105,7 +100,5 @@ function [errorsRMSE, errorsMax, Nsz, errorsRMSE_Median, errorsMax_Median] = Con
     data(:,3) = errorsMax;
     header = 'N, RMSE, Max';
     export_csv(['results/' name '.csv'], data, header);
-    
-    
-    
+
 end


### PR DESCRIPTION
`grep -i -r --include="*.m" --exclude-dir="dependencies" "contains"` only shows appearances in doc-strings now.



